### PR TITLE
Adding PostgresConnection type hint to BaseReader and BaseWriter

### DIFF
--- a/pyopenetl/operations.py
+++ b/pyopenetl/operations.py
@@ -24,7 +24,10 @@ class BaseReader:
     """
 
     def __init__(
-        self, source_conn: Union[HerokuConnection, CloudSQLConnection, BQConnection]
+        self,
+        source_conn: Union[
+            HerokuConnection, CloudSQLConnection, BQConnection, PostgresConnection
+        ],
     ) -> None:
         self.source_conn = source_conn
 
@@ -96,8 +99,12 @@ class BaseWriter:
 
     def __init__(
         self,
-        source_conn: Union[HerokuConnection, CloudSQLConnection, BQConnection, None],
-        dest_conn: Union[HerokuConnection, CloudSQLConnection, BQConnection],
+        source_conn: Union[
+            HerokuConnection, CloudSQLConnection, BQConnection, PostgresConnection, None
+        ],
+        dest_conn: Union[
+            HerokuConnection, CloudSQLConnection, BQConnection, PostgresConnection
+        ],
     ) -> None:
         self.source_conn = source_conn
         self.dest_conn = dest_conn
@@ -267,7 +274,9 @@ class CloudSQLWriter(BaseWriter):
 
     def __init__(
         self,
-        source_conn: Union[HerokuConnection, CloudSQLConnection, BQConnection],
+        source_conn: Union[
+            HerokuConnection, CloudSQLConnection, BQConnection, PostgresConnection
+        ],
         dest_conn: CloudSQLConnection,
     ) -> None:
         assert isinstance(dest_conn, CloudSQLConnection), TypeError(


### PR DESCRIPTION
Added PostgresConnection class to type hint for the BaseReader and BaseWriter classes, since its somewhat misleading to not have it there even though I've used these classes to pull data from the Mixrank VM. Let me know if you see any issues with this!